### PR TITLE
two speed optimizations

### DIFF
--- a/appinfo/ocsmsapp.php
+++ b/appinfo/ocsmsapp.php
@@ -145,12 +145,12 @@ class OcSmsApp extends App {
 				else {
 					$this->pushPhoneNumberToCache($phoneIds, $r["FN"], $configuredCountry);
 				}
-			}
-
-			if (isset ($r["PHOTO"])) {
-				// Remove useless prefix
-				$photoURL = preg_replace("#VALUE=uri:#","",$r["PHOTO"]);
-				self::$contactPhotos[$r["FN"]] = $photoURL;
+				
+				if (isset ($r["PHOTO"])) {
+					// Remove useless prefix
+					$photoURL = preg_replace("#VALUE=uri:#","",$r["PHOTO"]);
+					self::$contactPhotos[$r["FN"]] = $photoURL;
+				}
 			}
 		}
 	}

--- a/appinfo/ocsmsapp.php
+++ b/appinfo/ocsmsapp.php
@@ -148,7 +148,7 @@ class OcSmsApp extends App {
 				
 				if (isset ($r["PHOTO"])) {
 					// Remove useless prefix
-					$photoURL = preg_replace("#VALUE=uri:#","",$r["PHOTO"]);
+					$photoURL = preg_replace("#^VALUE=uri:#","",$r["PHOTO"], 1);
 					self::$contactPhotos[$r["FN"]] = $photoURL;
 				}
 			}


### PR DESCRIPTION
### 1: don't check for a photo unless any phone number given …
since the identification / matching between contact and sms is the sms_address (which is compared with TEL entries) it makes no sense to check for the photo, unless there is at least one address given (the sms_address can also be a text string, but this would still match only in TEL entries).

### 2:  minor regex optimization
probably not really neccessary but it was ment to improve speed since the replacment only takes place 
- at the beginning of the string
- once


