### PR TITLE
PhoneNumberFormatter: only remove a single zero in braces

### DIFF
--- a/lib/phonenumberformatter.php
+++ b/lib/phonenumberformatter.php
@@ -46,13 +46,13 @@ class PhoneNumberFormatter {
 
 		$ignrxp = array(					// match non digits and +
 			'#[^\d\+\(\)\[\]\{\}]#',			// everything but digit, +, (), [] or {}
-			'#(.+)([\(\[\{]\d*[\)\]\}])#',			// braces inside the number: +49 (0) 123 456789
+			'#([\(\[\{]0[\)\]\}])#',			// braces inside the number: +49 (0) 123 456789
 			'#[^\d\+]#'					// everything but digits and +
 		);
 
 		$ignrpl = array(					// replacements
 			'',
-			'$1',
+			'',
 			''
 		);
 		


### PR DESCRIPTION
the current code removes any numbers within braces, e.g. (0) | {123} | [007] (any combination of opening and closing braces is possible.

while this ensures to clean phone numbers like the given example "+49 (0) 123 456789" it also removes the em-braced numers in the other common form of phone number formatting, e.g. "+41 (12) 345 67 89" where the "12" is part of the international number and would be dialed like "012 345 67 89" within the given country.

the new code does only remove a single zero "0" within any combination of braces. thus 
"+49 (0) 123 456789" => "+49123456789"
"+41 (12) 345 67 89" => "+41123456789"

if this does not work in other situations, one shouldconcider a config option with either switching between a set of behaveours, or add it to the country information (lib/countrycodes.php) or add a free replacment set.