### PR TITLE
Fix crash appinfo

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
     <author>Loic Blot</author>
     <version>1.6.2</version>
     <requiremin>7</requiremin>
-    <requiremax>9</requiremin>
+    <requiremax>9</requiremax>
 
     <ocsid>167289</ocsid>
     


### PR DESCRIPTION
The 1.6.2 can't be enabled anymore.

This is due to a typo on the appinfo/info.xml