### PR TITLE
Fix #130 Use loading spinner from core

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,27 +216,7 @@ label {
 	font-weight: bold;
 }
 
-.loader,
-.loader:before,
-.loader:after {
-	background: #646464;
-	-webkit-animation: load1 1s infinite ease-in-out;
-	animation: load1 1s infinite ease-in-out;
-	width: 1em;
-	height: 4em;
-}
-.loader:before,
-.loader:after {
-	position: absolute;
-	top: 0;
-	content: '';
-}
-.loader:before {
-	left: -1.5em;
-	-webkit-animation-delay: -0.32s;
-	animation-delay: -0.32s;
-}
-.loader {
+.icon-loading {
 	color: #646464;
 	text-indent: -9999em;
 	margin: 88px auto;
@@ -247,31 +227,4 @@ label {
 	transform: translateZ(0);
 	-webkit-animation-delay: -0.16s;
 	animation-delay: -0.16s;
-}
-.loader:after {
-	left: 1.5em;
-}
-@-webkit-keyframes load1 {
-	0%,
-	80%,
-	100% {
-		box-shadow: 0 0;
-		height: 4em;
-	}
-	40% {
-		box-shadow: 0 -2em;
-		height: 5em;
-	}
-}
-@keyframes load1 {
-	0%,
-	80%,
-	100% {
-		box-shadow: 0 0;
-		height: 4em;
-	}
-	40% {
-		box-shadow: 0 -2em;
-		height: 5em;
-	}
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -8,7 +8,7 @@ use \OCA\OcSms\Lib\CountryCodes;
 
 <div class="ng-scope" id="app" ng-app="OcSms" ng-controller="OcSmsController">
 	<div id="app-mailbox-peers">
-		<div id="app-contacts-loader" class="loader" ng-show="isContactsLoading">
+		<div id="app-contacts-loader" class="icon-loading" ng-show="isContactsLoading">
 		</div>
 		<ul class="contact-list" ng-show="!isContactsLoading">
 			<li ng-repeat="contact in contacts | orderBy:setting_contactOrder:setting_contactOrderReverse" peer-label="{{ contact.label }}" ng-click="loadConversation(contact);" href="#">
@@ -58,7 +58,7 @@ use \OCA\OcSms\Lib\CountryCodes;
 	</div>
 
 	<div id="app-content">
-		<div id="app-content-loader" class="loader" ng-show="isConvLoading">
+		<div id="app-content-loader" class="icon-loading" ng-show="isConvLoading">
 		</div>
 		<div id="app-content-header" ng-show="!isConvLoading && selectedContact.label !== undefined && selectedContact.label !== ''"
 			 ng-style="{'background-color': (selectedContact.label | peerColor)}">


### PR DESCRIPTION
Even if i like the spinner since it is more funky than the one in the core i provide this PR to remove the spinner and use the one from core for a more consistent look &  feel across all Nextcloud Apps.

In the left sidebar you can see the spinner from core (This PR also uses the spinner in the "main view" - can not be seen in this screenshot):

![loading-icon from core](https://cloud.githubusercontent.com/assets/4741199/21222113/9d0b3444-c2c0-11e6-892f-5196ff98189e.png)
